### PR TITLE
[MOD] Change ext_emconf restrictions to TYPO3 V10 to keep keep typo3console happy while upgrading…

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -22,7 +22,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '4.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-9.5.99',
+            'typo3' => '8.7.0-10.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
…e happy while upgrading.