### PR TITLE
Fix footnote index not being calculated in records

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -10,6 +10,7 @@ services:
     AOE\HappyFeet\Typo3\Hook\LinkRenderer:
 
     AOE\HappyFeet\Typo3\Hook\Tcemain:
+        public: true
 
     AOE\HappyFeet\Service\RenderingService:
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,3 +16,5 @@ ExtensionManagementUtility::addPageTSConfig(
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['happy_feet'] = LinkRenderer::class;
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['linkHandler']['happy_feet'] = LinkHandler::class;
+
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][1737467472] = \AOE\HappyFeet\Typo3\Hook\Tcemain::class;


### PR DESCRIPTION
The post processor which is supposed to trigger the calculation of the next free index never got registered. This commit registers the post processor and enables DI which is needed for the processor.